### PR TITLE
Build a fully contained static binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ go.work
 tmp/
 build/
 go-dims
+
+.idea/copilot

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,20 @@
 all:
 	go build -o ./build/dims go-dims.go
 
+static:
+	go build -o ./build/dims -ldflags "-linkmode 'external' -extldflags '-fno-PIC -static -Wl,-z,stack-size=8388608 -lpng -lz -ltiff -lzstd -lwebp -lwebpmux -lwebpdemux -ljpeg -lbz2 -lfontconfig -lfreetype -lexpat -lbrotlidec -lbrotlienc -lbrotlicommon -llcms2'" go-dims.go
+
 docs:
 	mdbook build docs
 
 docs-serve:
 	mdbook serve docs
+
+docker-build: Dockerfile.build
+	docker buildx build --load -t beetlebugorg/go-dims:build . -f Dockerfile.build
+	docker images | grep beetlebugorg/go-dims
+
+docker: Dockerfile
+	docker buildx build --load -t beetlebugorg/go-dims:local .
+	docker images | grep beetlebugorg/go-dims
+


### PR DESCRIPTION
This reduces the container image from around 60-70mb to just under 10mb.

The image is also "distroless" meaning it has no binaries or utilities other than what is needed. Currently this is tzdata, ca-certificates, user/group files, and the dims binary.