### PR TITLE
Split transformation operations from export operations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,6 @@
 {
 	"name": "go-dims",
-	"build": {
-		"dockerfile": "../Dockerfile.builder",
-		"context": ".."
-	},
+	"image": "ghcr.io/beetlebugorg/go-dims:builder",
 
 	"containerUser": "root",
 	"remoteUser": "root",

--- a/internal/dims/operations/autolevel.go
+++ b/internal/dims/operations/autolevel.go
@@ -14,8 +14,10 @@
 
 package operations
 
-import "context"
+import (
+	"github.com/davidbyttow/govips/v2/vips"
+)
 
-func AutolevelCommand(ctx context.Context, args string) error {
+func AutolevelCommand(image *vips.ImageRef, args string) error {
 	return nil
 }

--- a/internal/dims/operations/brightness.go
+++ b/internal/dims/operations/brightness.go
@@ -15,11 +15,12 @@
 package operations
 
 import (
-	"context"
 	"log/slog"
+
+	"github.com/davidbyttow/govips/v2/vips"
 )
 
-func BrightnessCommand(ctx context.Context, args string) error {
+func BrightnessCommand(image *vips.ImageRef, args string) error {
 	slog.Debug("BrightnessCommand", "args", args)
 
 	//image := request.vipsImage

--- a/internal/dims/operations/command.go
+++ b/internal/dims/operations/command.go
@@ -16,6 +16,8 @@ package operations
 
 import (
 	"context"
+
+	"github.com/davidbyttow/govips/v2/vips"
 )
 
 type Command struct {
@@ -23,11 +25,22 @@ type Command struct {
 	Args string
 }
 
-type VipsOperation func(ctx context.Context, args string) error
+// Context passed to commands.
+type ExportOptions struct {
+	vips.ImageType
+	*vips.JpegExportParams
+	*vips.PngExportParams
+	*vips.WebpExportParams
+	*vips.GifExportParams
+	*vips.TiffExportParams
+}
 
-type VipsCommand struct {
+type VipsTransformOperation func(image *vips.ImageRef, args string) error
+type VipsExportOperation func(image *vips.ImageRef, args string, opts *ExportOptions) error
+
+type VipsCommand[T any] struct {
 	Command
-	Operation VipsOperation
+	Operation T
 }
 
 func PassThroughCommand(ctx context.Context, args string) error {

--- a/internal/dims/operations/crop.go
+++ b/internal/dims/operations/crop.go
@@ -1,17 +1,14 @@
 package operations
 
 import (
-	"context"
 	"strings"
 
 	"github.com/beetlebugorg/go-dims/internal/dims/geometry"
 	"github.com/davidbyttow/govips/v2/vips"
 )
 
-func CropCommand(ctx context.Context, args string) error {
+func CropCommand(image *vips.ImageRef, args string) error {
 	sanitizedArgs := strings.ReplaceAll(args, " ", "+")
-
-	image := ctx.Value("image").(*vips.ImageRef)
 
 	// Parse Geometry
 	rect := geometry.ParseGeometry(sanitizedArgs)

--- a/internal/dims/operations/flip-flop.go
+++ b/internal/dims/operations/flip-flop.go
@@ -15,16 +15,13 @@
 package operations
 
 import (
-	"context"
 	"log/slog"
 
 	"github.com/davidbyttow/govips/v2/vips"
 )
 
-func FlipFlopCommand(ctx context.Context, args string) error {
+func FlipFlopCommand(image *vips.ImageRef, args string) error {
 	slog.Debug("FlipFlopCommand", "args", args)
-
-	image := ctx.Value("image").(*vips.ImageRef)
 
 	if args == "horizontal" {
 		return image.Flip(vips.DirectionHorizontal)

--- a/internal/dims/operations/format.go
+++ b/internal/dims/operations/format.go
@@ -1,9 +1,27 @@
 package operations
 
-import "context"
+import (
+	"github.com/davidbyttow/govips/v2/vips"
+	"golang.org/x/exp/slog"
+)
 
-func FormatCommand(ctx context.Context, args string) error {
-	//format := strings.ToLower(args)
-	//request.format = &format
+func FormatCommand(image *vips.ImageRef, args string, opts *ExportOptions) error {
+	slog.Debug("FormatCommand", "args", args)
+
+	switch args {
+	case "jpeg", "jpg":
+		opts.ImageType = vips.ImageTypeJPEG
+	case "png":
+		opts.ImageType = vips.ImageTypePNG
+	case "webp":
+		opts.ImageType = vips.ImageTypeWEBP
+	case "gif":
+		opts.ImageType = vips.ImageTypeGIF
+	case "tiff", "tif":
+		opts.ImageType = vips.ImageTypeTIFF
+	}
+
+	slog.Debug("FormatCommand", "imagetype", opts.ImageType)
+
 	return nil
 }

--- a/internal/dims/operations/grayscale.go
+++ b/internal/dims/operations/grayscale.go
@@ -15,12 +15,9 @@
 package operations
 
 import (
-	"context"
-
 	"github.com/davidbyttow/govips/v2/vips"
 )
 
-func GrayscaleCommand(ctx context.Context, args string) error {
-	image := ctx.Value("image").(*vips.ImageRef)
+func GrayscaleCommand(image *vips.ImageRef, args string) error {
 	return image.ToColorSpace(vips.InterpretationBW)
 }

--- a/internal/dims/operations/invert.go
+++ b/internal/dims/operations/invert.go
@@ -15,12 +15,9 @@
 package operations
 
 import (
-	"context"
-
 	"github.com/davidbyttow/govips/v2/vips"
 )
 
-func InvertCommand(ctx context.Context, args string) error {
-	image := ctx.Value("image").(*vips.ImageRef)
+func InvertCommand(image *vips.ImageRef, args string) error {
 	return image.Invert()
 }

--- a/internal/dims/operations/quality.go
+++ b/internal/dims/operations/quality.go
@@ -15,13 +15,13 @@
 package operations
 
 import (
-	"context"
 	"strconv"
 
+	"github.com/davidbyttow/govips/v2/vips"
 	"github.com/sagikazarmark/slog-shim"
 )
 
-func QualityCommand(ctx context.Context, args string) error {
+func QualityCommand(image *vips.ImageRef, args string, opts *ExportOptions) error {
 	slog.Debug("QualityCommand", "args", args)
 
 	quality, err := strconv.Atoi(args)

--- a/internal/dims/operations/resize.go
+++ b/internal/dims/operations/resize.go
@@ -15,17 +15,13 @@
 package operations
 
 import (
-	"context"
-
 	"github.com/beetlebugorg/go-dims/internal/dims/geometry"
 	"github.com/davidbyttow/govips/v2/vips"
 	"github.com/sagikazarmark/slog-shim"
 )
 
-func ResizeCommand(ctx context.Context, args string) error {
+func ResizeCommand(image *vips.ImageRef, args string) error {
 	slog.Debug("ResizeCommand", "args", args)
-
-	image := ctx.Value("image").(*vips.ImageRef)
 
 	// Parse Geometry
 	geo := geometry.ParseGeometry(args)

--- a/internal/dims/operations/rotate.go
+++ b/internal/dims/operations/rotate.go
@@ -15,17 +15,14 @@
 package operations
 
 import (
-	"context"
 	"log/slog"
 	"strconv"
 
 	"github.com/davidbyttow/govips/v2/vips"
 )
 
-func RotateCommand(ctx context.Context, args string) error {
+func RotateCommand(image *vips.ImageRef, args string) error {
 	slog.Debug("RotateCommand", "args", args)
-
-	image := ctx.Value("image").(*vips.ImageRef)
 
 	degrees, err := strconv.ParseFloat(args, 64)
 	if err != nil {

--- a/internal/dims/operations/sepia.go
+++ b/internal/dims/operations/sepia.go
@@ -14,8 +14,8 @@
 
 package operations
 
-import "context"
+import "github.com/davidbyttow/govips/v2/vips"
 
-func SepiaCommand(ctx context.Context, args string) error {
+func SepiaCommand(image *vips.ImageRef, args string) error {
 	return nil
 }

--- a/internal/dims/operations/sharpen.go
+++ b/internal/dims/operations/sharpen.go
@@ -15,11 +15,12 @@
 package operations
 
 import (
-	"context"
 	"log/slog"
+
+	"github.com/davidbyttow/govips/v2/vips"
 )
 
-func SharpenCommand(ctx context.Context, args string) error {
+func SharpenCommand(image *vips.ImageRef, args string) error {
 	slog.Debug("SharpenCommand", "args", args)
 
 	//var geometry imagick.GeometryInfo

--- a/internal/dims/operations/strip.go
+++ b/internal/dims/operations/strip.go
@@ -1,11 +1,31 @@
+// Copyright 2024 Jeremy Collins. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package operations
 
-import "context"
+import (
+	"github.com/davidbyttow/govips/v2/vips"
+)
 
-func StripMetadataCommand(ctx context.Context, args string) error {
-	//request.exportJpegParams.StripMetadata = true
-	//request.exportWebpParams.StripMetadata = true
-	//request.exportPngParams.StripMetadata = true
+func StripMetadataCommand(image *vips.ImageRef, args string, ops *ExportOptions) error {
+	strip := "args" == "true"
+
+	ops.JpegExportParams.StripMetadata = strip
+	ops.PngExportParams.StripMetadata = strip
+	ops.WebpExportParams.StripMetadata = strip
+	ops.GifExportParams.StripMetadata = strip
+	ops.TiffExportParams.StripMetadata = strip
 
 	return nil
 }

--- a/internal/dims/operations/thumbnail.go
+++ b/internal/dims/operations/thumbnail.go
@@ -15,7 +15,6 @@
 package operations
 
 import (
-	"context"
 	"errors"
 	"log/slog"
 	"strings"
@@ -24,10 +23,8 @@ import (
 	"github.com/davidbyttow/govips/v2/vips"
 )
 
-func ThumbnailCommand(ctx context.Context, args string) error {
+func ThumbnailCommand(image *vips.ImageRef, args string) error {
 	slog.Debug("ThumbnailCommand", "args", args)
-
-	image := ctx.Value("image").(*vips.ImageRef)
 
 	// Remove any symbols and add a trailing '^' to the geometry. This ensures
 	// that the image will be at least as large as requested.
@@ -56,6 +53,6 @@ func ThumbnailCommand(ctx context.Context, args string) error {
 	return nil
 }
 
-func LegacyThumbnailCommand(ctx context.Context, args string) error {
+func LegacyThumbnailCommand(image *vips.ImageRef, args string) error {
 	return nil
 }


### PR DESCRIPTION
This is necessary because of how vips works. Rather than change the format of an imageRef, you export using to a specific format. This requires export commands to set their options in a way that can be passed back to the kernel.