### PR TITLE
Implement health-check command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ COPY --from=go-dims /etc/passwd /etc/passwd
 COPY --from=go-dims /etc/group /etc/group
 COPY --from=go-dims --chown=10001:10001 /tmp /tmp
 
+HEALTHCHECK --interval=5s --timeout=2s --start-period=5s --retries=3 \
+    CMD /dims health-check || exit 1
+
 ENTRYPOINT ["/dims"]
 CMD ["serve"]
 EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,6 @@ builder:
 	docker buildx build --push --platform linux/amd64,linux/arm64 -t ghcr.io/beetlebugorg/go-dims:builder -f Dockerfile.builder .
 
 devmedia:
-	docker run --rm --name go-dims-devmedia --privileged -p 8081:80 -v ./devmedia:/usr/share/nginx/html:ro nginx:latest
+	docker run --rm --name go-dims-devmedia --privileged -p 8081:80 -v ./resources:/usr/share/nginx/html:ro nginx:latest
 
 .PHONY: docs docs-serve devmedia

--- a/go-dims.go
+++ b/go-dims.go
@@ -96,10 +96,12 @@ func (e *DecryptionCmd) Run() error {
 	return nil
 }
 
-type HealthCheckCmd struct{}
+type HealthCheckCmd struct {
+	Port int `help:"Port to check." default:"8080"`
+}
 
-func (*HealthCheckCmd) Run() error {
-	url := "http://localhost:8080/healthz"
+func (h *HealthCheckCmd) Run() error {
+	url := fmt.Sprintf("http://localhost:%d/healthz", h.Port)
 	client := http.Client{
 		Timeout: 2 * time.Second,
 	}

--- a/go-dims.go
+++ b/go-dims.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/beetlebugorg/go-dims/internal/dims/core"
@@ -95,16 +96,32 @@ func (e *DecryptionCmd) Run() error {
 	return nil
 }
 
+type HealthCheckCmd struct{}
+
+func (*HealthCheckCmd) Run() error {
+	url := "http://localhost:8080/healthz"
+	client := http.Client{
+		Timeout: 2 * time.Second,
+	}
+	resp, err := client.Get(url)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("health check failed: %v", err)
+	}
+
+	return nil
+}
+
 var CLI struct {
-	Serve   ServeCmd      `cmd:"" help:"Runs the DIMS service."`
-	Encrypt EncryptionCmd `cmd:"" help:"Encrypt an eurl."`
-	Decrypt DecryptionCmd `cmd:"" help:"Decrypt an eurl."`
+	Serve       ServeCmd       `cmd:"" help:"Runs the DIMS service."`
+	Encrypt     EncryptionCmd  `cmd:"" help:"Encrypt an eurl."`
+	Decrypt     DecryptionCmd  `cmd:"" help:"Decrypt an eurl."`
+	HealthCheck HealthCheckCmd `cmd:"" help:"Check the health of the DIMS service."`
 }
 
 func main() {
 	ctx := kong.Parse(&CLI)
 	err := ctx.Run()
 	if err != nil {
-		return
+		os.Exit(1)
 	}
 }

--- a/pkg/dims/handler.go
+++ b/pkg/dims/handler.go
@@ -85,7 +85,11 @@ func NewHandler(debug bool, dev bool) http.Handler {
 			}
 		})
 
-	mux.HandleFunc("/dims-status",
+	mux.HandleFunc("/dims-status/",
+		func(w http.ResponseWriter, r *http.Request) {
+			dims.HandleDimsStatus(environmentConfig, debug, dev, w, r)
+		})
+	mux.HandleFunc("/healthz",
 		func(w http.ResponseWriter, r *http.Request) {
 			dims.HandleDimsStatus(environmentConfig, debug, dev, w, r)
 		})


### PR DESCRIPTION
Since the docker image is built `FROM scratch` there is no way to implement a HEALTHCHECK in Dockerfile, or docker compose. This PR implements a simple command to ping the /healthz endpoint.