### PR TITLE
Implement s3 and http image backends

### DIFF
--- a/internal/aws/s3.go
+++ b/internal/aws/s3.go
@@ -1,0 +1,103 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/beetlebugorg/go-dims/internal/core"
+	"github.com/caarlos0/env/v10"
+	"github.com/davidbyttow/govips/v2/vips"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+var client *s3.Client
+
+type imageBackend struct {
+	Config core.S3
+}
+
+func init() {
+	envConfig := core.S3{}
+	if err := env.Parse(&envConfig); err != nil {
+		fmt.Printf("%+v\n", err)
+	}
+
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		slog.Error("failed to load configuration", "error", err)
+	}
+
+	client = s3.NewFromConfig(cfg)
+
+	core.RegisterImageBackend(NewImageBackend(envConfig))
+}
+
+func NewImageBackend(config core.S3) core.ImageBackend {
+	return imageBackend{
+		Config: config,
+	}
+}
+
+func (backend imageBackend) Name() string {
+	return "s3"
+}
+
+func (backend imageBackend) CanHandle(imageSource string) bool {
+	if strings.HasPrefix(imageSource, "s3://") {
+		return true
+	}
+
+	return false
+}
+
+func (backend imageBackend) FetchImage(imageSource string, timeout time.Duration) (*core.Image, error) {
+	slog.Info("downloadImageS3", "url", imageSource)
+
+	bucketName := backend.Config.Bucket
+	key := strings.TrimPrefix(imageSource, "/")
+
+	if strings.HasPrefix(imageSource, "s3://") {
+		u, err := url.Parse(imageSource)
+		if err != nil {
+			return nil, err
+		}
+
+		bucketName = u.Hostname()
+		key = strings.TrimPrefix(u.Path, "/")
+	}
+
+	response, err := client.GetObject(context.TODO(), &s3.GetObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(key),
+	})
+
+	if err != nil {
+		slog.Debug("s3.GetObject failed", "bucket", bucketName, "key", key)
+		return nil, err
+	}
+
+	lastModified := response.LastModified.Format(http.TimeFormat)
+	size := int(*response.ContentLength)
+	imageBytes, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceImage := core.Image{
+		Status:       200,
+		Etag:         *response.ETag,
+		Size:         size,
+		Bytes:        imageBytes,
+		Format:       vips.ImageTypes[vips.DetermineImageType(imageBytes)],
+		LastModified: lastModified,
+	}
+
+	return &sourceImage, nil
+}

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -33,7 +33,6 @@ type EdgeControl struct {
 }
 
 type Error struct {
-	Image      string `env:"DIMS_ERROR_IMAGE" envDefault:""`
 	Background string `env:"DIMS_ERROR_BACKGROUND" envDefault:"#5ADAFD"`
 }
 
@@ -85,6 +84,7 @@ type ImageOutputOptions struct {
 }
 
 type S3 struct {
+	Region string `env:"DIMS_S3_REGION" envDefault:""`
 	Bucket string `env:"DIMS_S3_BUCKET" envDefault:""`
 	Prefix string `env:"DIMS_S3_PREFIX" envDefault:""`
 }
@@ -93,6 +93,7 @@ type Config struct {
 	BindAddress     string `env:"DIMS_BIND_ADDRESS" envDefault:":8080"`
 	DevelopmentMode bool   `env:"DIMS_DEVELOPMENT_MODE" envDefault:"false"`
 	DebugMode       bool   `env:"DIMS_DEBUG_MODE" envDefault:"false"`
+	ImageBackend    string `env:"DIMS_DEFAULT_IMAGE_BACKEND" envDefault:"http"`
 	EtagAlgorithm   string
 
 	Timeout
@@ -103,7 +104,6 @@ type Config struct {
 	OutputFormat
 	Options
 	ImageOutputOptions
-	S3
 }
 
 func ReadConfig() Config {

--- a/internal/http/image.go
+++ b/internal/http/image.go
@@ -1,0 +1,98 @@
+// Copyright 2025 Jeremy Collins. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"fmt"
+	"github.com/beetlebugorg/go-dims/internal/core"
+	"github.com/davidbyttow/govips/v2/vips"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type imageBackend struct {
+}
+
+func init() {
+	core.RegisterImageBackend(NewImageBackend())
+}
+
+func NewImageBackend() core.ImageBackend {
+	return imageBackend{}
+}
+
+func (backend imageBackend) Name() string {
+	return "http"
+}
+
+func (backend imageBackend) CanHandle(imageSource string) bool {
+	if strings.HasPrefix(imageSource, "http://") || strings.HasPrefix(imageSource, "https://") {
+		return true
+	}
+
+	return false
+}
+
+func (backend imageBackend) FetchImage(imageUrl string, timeout time.Duration) (*core.Image, error) {
+	slog.Debug("downloadImage", "url", imageUrl)
+
+	_, err := url.ParseRequestURI(imageUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := http.NewRequest("GET", imageUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	request.Header.Set("User-Agent", fmt.Sprintf("go-dims/%s", core.Version))
+
+	http.DefaultClient.Timeout = timeout
+	image, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	imageSize := int(image.ContentLength)
+	imageBytes, err := io.ReadAll(image.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceImage := core.Image{
+		Status:       image.StatusCode,
+		EdgeControl:  image.Header.Get("Edge-Control"),
+		CacheControl: image.Header.Get("Cache-Control"),
+		LastModified: image.Header.Get("Last-Modified"),
+		Etag:         image.Header.Get("Etag"),
+		Format:       vips.ImageTypes[vips.DetermineImageType(imageBytes)],
+		Size:         imageSize,
+		Bytes:        imageBytes,
+	}
+
+	if image.StatusCode != 200 {
+		return nil, &core.StatusError{
+			Message:    fmt.Sprintf("failed to fetch image from %s", imageUrl),
+			StatusCode: image.StatusCode,
+		}
+	}
+
+	return &sourceImage, nil
+}

--- a/internal/v4/request.go
+++ b/internal/v4/request.go
@@ -59,14 +59,14 @@ func (v4 *Request) HashId() string {
 }
 
 func (v4 *Request) Validate() bool {
-	return ValidateSignature(v4.Signature, v4.clientId, v4.timestamp, v4.ImageUrl, v4.SignedParams, v4.Config().SigningKey)
+	return ValidateSignature(v4.Signature, v4.RawCommands, v4.timestamp, v4.ImageUrl, v4.SignedParams, v4.Config().SigningKey)
 }
 
-func ValidateSignature(signature, clientId, timestamp, imageUrl string, signedParams map[string]string, signingKey string) bool {
+func ValidateSignature(signature, commands, timestamp, imageUrl string, signedParams map[string]string, signingKey string) bool {
 	h := md5.New()
-	h.Write([]byte(clientId))
 	h.Write([]byte(timestamp))
 	h.Write([]byte(signingKey))
+	h.Write([]byte(commands))
 	h.Write([]byte(imageUrl))
 
 	for _, signedParam := range signedParams {

--- a/internal/v5/request.go
+++ b/internal/v5/request.go
@@ -43,11 +43,12 @@ func NewRequest(r *http.Request, w http.ResponseWriter, config core.Config) (*Re
 
 // Validate verifies the signature of the image resize is valid.
 func (v5 *Request) Validate() bool {
-	return ValidateSignature(v5.Signature, v5.ImageUrl, v5.SignedParams, v5.Config().SigningKey)
+	return ValidateSignature(v5.Signature, v5.ImageUrl, v5.SignedParams, v5.RawCommands, v5.Config().SigningKey)
 }
 
-func ValidateSignature(signature, imageUrl string, signedParams map[string]string, signingKey string) bool {
+func ValidateSignature(signature, imageUrl string, signedParams map[string]string, command string, signingKey string) bool {
 	mac := hmac.New(sha256.New, []byte(signingKey))
+	mac.Write([]byte(command))
 	mac.Write([]byte(imageUrl))
 
 	for _, signedParam := range signedParams {

--- a/pkg/dims/handler.go
+++ b/pkg/dims/handler.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	_ "github.com/beetlebugorg/go-dims/internal/aws"
 	"github.com/beetlebugorg/go-dims/internal/dims"
 )
 


### PR DESCRIPTION
DIMS_DEFAULT_IMAGE_BACKEND defaults to http, and http is always an option.

If a scheme is not provided (i.e. ?url=image.jpg) then the default image backend will be used. This allows users to pull images from S3 without providing the bucket name externally.

For the default image backend to work for s3, DIMS_S3_BUCKET must be set.