### PR TITLE
Implement default output format

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -41,8 +41,8 @@ type Signing struct {
 }
 
 type OutputFormat struct {
-	OutputFormat string   `env:"DIMS_OUTPUT_FORMAT"`
-	Exclude      []string `env:"DIMS_OUTPUT_FORMAT_EXCLUDE"`
+	Default  string   `env:"DIMS_DEFAULT_OUTPUT_FORMAT"`
+	Excluded []string `env:"DIMS_EXCLUDED_OUTPUT_FORMATS"`
 }
 
 type Timeout struct {

--- a/internal/core/image.go
+++ b/internal/core/image.go
@@ -26,14 +26,14 @@ import (
 )
 
 type Image struct {
-	Bytes        []byte // The downloaded image.
-	Size         int    // The original image size in bytes.
-	Format       string // The original image format.
-	Status       int    // The HTTP status code of the downloaded image.
-	CacheControl string // The cache headers from the downloaded image.
-	EdgeControl  string // The edge control headers from the downloaded image.
-	LastModified string // The last modified header from the downloaded image.
-	Etag         string // The etag header from the downloaded image.
+	Bytes        []byte         // The downloaded image.
+	Size         int            // The original image size in bytes.
+	Format       vips.ImageType // The original image format.
+	Status       int            // The HTTP status code of the downloaded image.
+	CacheControl string         // The cache headers from the downloaded image.
+	EdgeControl  string         // The edge control headers from the downloaded image.
+	LastModified string         // The last modified header from the downloaded image.
+	Etag         string         // The etag header from the downloaded image.
 }
 
 var ImageTypes = map[string]vips.ImageType{

--- a/internal/source/file.go
+++ b/internal/source/file.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"github.com/beetlebugorg/go-dims/internal/core"
 	"github.com/caarlos0/env/v10"
+	"github.com/davidbyttow/govips/v2/vips"
 	"io"
 	"os"
 	"path/filepath"
@@ -79,6 +80,7 @@ func (f fileSourceBackend) FetchImage(imageSource string, timeout time.Duration)
 		Status: 200,
 		Size:   len(imageBytes),
 		Bytes:  imageBytes,
+		Format: vips.DetermineImageType(imageBytes),
 	}, nil
 }
 

--- a/internal/source/http.go
+++ b/internal/source/http.go
@@ -82,7 +82,7 @@ func (backend httpSourceBackend) FetchImage(imageUrl string, timeout time.Durati
 		CacheControl: image.Header.Get("Cache-Control"),
 		LastModified: image.Header.Get("Last-Modified"),
 		Etag:         image.Header.Get("Etag"),
-		Format:       vips.ImageTypes[vips.DetermineImageType(imageBytes)],
+		Format:       vips.DetermineImageType(imageBytes),
 		Size:         imageSize,
 		Bytes:        imageBytes,
 	}

--- a/internal/source/s3.go
+++ b/internal/source/s3.go
@@ -95,7 +95,7 @@ func (backend s3SourceBackend) FetchImage(imageSource string, timeout time.Durat
 		Etag:         *response.ETag,
 		Size:         size,
 		Bytes:        imageBytes,
-		Format:       vips.ImageTypes[vips.DetermineImageType(imageBytes)],
+		Format:       vips.DetermineImageType(imageBytes),
 		LastModified: lastModified,
 	}
 


### PR DESCRIPTION
Format precedence is:

- format/<type> command in url
- default output format
- original format

Except is SVG and GIF since these cannot currently be exported they will always be PNG if default output format is not set, or the format is not provided in the url.